### PR TITLE
New release v1.4.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.github.cetoolbox"
         minSdkVersion 19
         targetSdkVersion 29
-        versionCode 11
-        versionName "1.4.3"
+        versionCode 13
+        versionName "1.4.5"
     }
 
     buildTypes {

--- a/app/src/main/java/com/github/cetoolbox/CEToolboxActivity.java
+++ b/app/src/main/java/com/github/cetoolbox/CEToolboxActivity.java
@@ -132,7 +132,7 @@ public class CEToolboxActivity extends TabActivity {
 						.getLong("electroOsmosisTime",
 								Double.doubleToLongBits(100.0))));
 		fragmentData.setConcentrationSpinPosition(preferences.getInt(
-				"concentrationSpinPosition", 0));
+				"concentrationSpinPosition", 1));
 		fragmentData.setPressureSpinPosition(preferences.getInt(
 				"pressureSpinPosition", 0));
 		fragmentData.setDetectionTimeSpinPosition(preferences.getInt(

--- a/app/src/main/java/com/github/cetoolbox/CapillaryElectrophoresis.java
+++ b/app/src/main/java/com/github/cetoolbox/CapillaryElectrophoresis.java
@@ -182,7 +182,7 @@ public class CapillaryElectrophoresis {
 	public double getConductivity() {
 		double conductivity;
 		conductivity = (4 * totalLength * Math.pow(10, 4) * electricCurrent)
-				/ (Math.PI * Math.pow(diameter, 2) * voltage);
+				/ (Math.PI * Math.pow(diameter, 2) * voltage) * Math.pow(10, 3);
 		return conductivity;
 	}
 
@@ -195,21 +195,21 @@ public class CapillaryElectrophoresis {
 	public double getMicroEOF() {
 		double microEOF;
 		microEOF = (totalLength * toWindowLength)
-				/ (electroOsmosisTime * voltage);
+				/ (electroOsmosisTime * voltage) * Math.pow(10, -4);
 		return microEOF;
 	}
 
 	public double getMicroEFF(double peakTime) {
 		double microEFF;
 		microEFF = (totalLength * toWindowLength)
-				/ (peakTime * voltage);
+				/ (peakTime * voltage) * Math.pow(10, -4);
 		return microEFF;
 	}
 
 	public double getLengthPerMinute() {
 		double lengthPerMinute;
 		lengthPerMinute = (60 * getMicroEOF() * getFieldStrength() * Math.pow(
-				10, -2));
+				10, 2));
 		return lengthPerMinute;
 	}
 

--- a/app/src/main/java/com/github/cetoolbox/fragments/tabs/ConductivityActivity.java
+++ b/app/src/main/java/com/github/cetoolbox/fragments/tabs/ConductivityActivity.java
@@ -225,7 +225,7 @@ public class ConductivityActivity extends Activity implements
 				capillary.setElectricCurrent(electricCurrent);
 
 				DecimalFormat doubleDecimalFormat = new DecimalFormat("#.##");
-				Double conductivity = capillary.getConductivity(); /* nl */
+				Double conductivity = capillary.getConductivity(); /* mS/m */
 
 				/* Build the result window */
 				LayoutInflater li = LayoutInflater.from(this);
@@ -248,7 +248,7 @@ public class ConductivityActivity extends Activity implements
 				TextView tvConductivity = (TextView) conductivityDetailsView
 						.findViewById(R.id.conductivityValue);
 				tvConductivity.setText(doubleDecimalFormat.format(conductivity)
-						+ " S/m");
+						+ " mS/m");
 
 				builder.setNeutralButton("Close",
 						new DialogInterface.OnClickListener() {

--- a/app/src/main/java/com/github/cetoolbox/fragments/tabs/FlowrateActivity.java
+++ b/app/src/main/java/com/github/cetoolbox/fragments/tabs/FlowrateActivity.java
@@ -260,7 +260,7 @@ public class FlowrateActivity extends Activity implements
 
 				/* Compute the microEOF mobility if the electro-osmosis time is not infinite*/
 				if (electroOsmosisTimeSpinPosition < 2) {
-					microEOF = capillary.getMicroEOF(); /* E-3 cm2/V/s */
+					microEOF = capillary.getMicroEOF(); /* m2/(V.s) */
 				}
 				Double lengthPerMinute = capillary.getLengthPerMinute(); /* m */
 				Double flowRate = capillary.getFlowRate(); /* nL/min */
@@ -290,7 +290,7 @@ public class FlowrateActivity extends Activity implements
 				TextView tvMicroEOF = (TextView) flowRateDetailsView
 						.findViewById(R.id.microEOFValue);
 				tvMicroEOF.setText(doubleDecimalScientificFormat.format(microEOF)
-						+ " cm2/V/s");
+						+ " m2/(V.s)");
 				TextView tvLengthPerMinute = (TextView) flowRateDetailsView
 						.findViewById(R.id.lengthPerMinuteValue);
 				tvLengthPerMinute.setText(doubleDecimalFormat

--- a/app/src/main/java/com/github/cetoolbox/fragments/tabs/InjectionActivity.java
+++ b/app/src/main/java/com/github/cetoolbox/fragments/tabs/InjectionActivity.java
@@ -470,7 +470,7 @@ public class InjectionActivity extends Activity implements
             duration = 10.0;
             viscosity = 1.0;
             concentration = 1.0;
-            concentrationSpinPosition = 0;
+            concentrationSpinPosition = 1;
             molecularWeight = 1000.0;
             voltage = 30000.0;
 

--- a/app/src/main/java/com/github/cetoolbox/fragments/tabs/MobilityActivity.java
+++ b/app/src/main/java/com/github/cetoolbox/fragments/tabs/MobilityActivity.java
@@ -312,7 +312,7 @@ public class MobilityActivity extends Activity implements
                 TextView tvMicroEOF = (TextView) mobilityDetailsView
                         .findViewById(R.id.microEOFValue);
                 tvMicroEOF.setText(doubleDecimalScientificFormat.format(microEOF)
-                        + " cm2/V/s");
+                        + " m2/(V.s)");
                 boolean endOfPeaks = false;
                 TextView[] tvMicroEFF = new TextView[CEToolboxActivity.timePeakCount];
                 String microeff_name;
@@ -328,7 +328,7 @@ public class MobilityActivity extends Activity implements
                     if (!endOfPeaks) {
                         microEFF = capillary.getMicroEFF(timePeaks[i] * 60) - microEOF;
                         /* Display the value of mobility for this peak */
-                        tvMicroEFF[i].setText(doubleDecimalScientificFormat.format(microEFF) + " cm2/V/s");
+                        tvMicroEFF[i].setText(doubleDecimalScientificFormat.format(microEFF) + " m2/(V.s)");
                     } else {
                         tvMicroEFF[i].setText("-");
                         /* Hide the value for this peak */

--- a/app/src/main/res/layout/about.xml
+++ b/app/src/main/res/layout/about.xml
@@ -72,6 +72,18 @@
             android:layout_weight="1"
             android:autoLink="web"
             android:padding="5dp"
+            android:text="@string/About_equations" />
+    </TableRow>
+
+    <TableRow
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:layout_span="2"
+            android:layout_weight="1"
+            android:autoLink="web"
+            android:padding="5dp"
             android:text="@string/About_license" />
     </TableRow>
 </TableLayout>

--- a/app/src/main/res/values-en-rUS/strings.xml
+++ b/app/src/main/res/values-en-rUS/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Copyright (C) 2012-2014 CNRS and University of Strasbourg
+  Copyright (C) 2012-2019 CNRS and University of Strasbourg
   
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -57,7 +57,8 @@
     <string name="About_description">The Capillary Electrophoresis (CE) Toolbox is a software for computing
     Capillary Electrophoresis parameters developed by the <a href="https://complex-matter.unistra.fr/equipes-de-recherche/laboratoire-de-spectrometrie-de-masse-des-interactions-et-des-systemes/accueil/">LSMIS</a>
     and the <a href="http://www.iphc.cnrs.fr">IPHC</a> laboratories.</string>
-    <string name="About_website">For more informations, visit the website: <a href="https://cetoolbox.github.io/">https://cetoolbox.github.io/</a></string>
+    <string name="About_equations">The theoretical equations used by CEToolbox are described in the following document: <a href="https://cetoolbox.github.io/resources/cetoolbox-equations.pdf">https://cetoolbox.github.io/resources/cetoolbox-equations.pdf</a></string>
+    <string name="About_website">For more information, visit the website: <a href="https://cetoolbox.github.io/">https://cetoolbox.github.io/</a></string>
     <string name="About_license">CEToolbox is
     licensed under the Apache License, Version 2.0. You may obtain a copy of the License at: <a href="https://www.apache.org/licenses/LICENSE-2.0.txt">https://www.apache.org/licenses/LICENSE-2.0.txt</a></string>
     <string name="TimePeak1">Time peak 1</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Copyright (C) 2012-2014 CNRS and University of Strasbourg
+  Copyright (C) 2012-2019 CNRS and University of Strasbourg
   
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -57,7 +57,8 @@
     <string name="About_description">The Capillary Electrophoresis (CE) Toolbox is a software for computing
     Capillary Electrophoresis parameters developed by the <a href="https://complex-matter.unistra.fr/equipes-de-recherche/laboratoire-de-spectrometrie-de-masse-des-interactions-et-des-systemes/accueil/">LSMIS</a>
     and the <a href="http://www.iphc.cnrs.fr">IPHC</a> laboratories.</string>
-    <string name="About_website">For more informations, visit the website: <a href="https://cetoolbox.github.io/">https://cetoolbox.github.io/</a></string>
+    <string name="About_equations">The theoretical equations used by CEToolbox are described in the following document: <a href="https://cetoolbox.github.io/resources/cetoolbox-equations.pdf">https://cetoolbox.github.io/resources/cetoolbox-equations.pdf</a></string>
+    <string name="About_website">For more information, visit the website: <a href="https://cetoolbox.github.io/">https://cetoolbox.github.io/</a></string>
     <string name="About_license">CEToolbox is
     licensed under the Apache License, Version 2.0. You may obtain a copy of the License at: <a href="https://www.apache.org/licenses/LICENSE-2.0.txt">https://www.apache.org/licenses/LICENSE-2.0.txt</a></string>
     <string name="TimePeak1">Time peak 1</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Copyright (C) 2012-2014 CNRS and University of Strasbourg
+  Copyright (C) 2012-2019 CNRS and University of Strasbourg
   
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -57,7 +57,8 @@
     <string name="About_description">The Capillary Electrophoresis (CE) Toolbox is a software for computing
     Capillary Electrophoresis parameters developed by the <a href="https://complex-matter.unistra.fr/equipes-de-recherche/laboratoire-de-spectrometrie-de-masse-des-interactions-et-des-systemes/accueil/">LSMIS</a>
     and the <a href="http://www.iphc.cnrs.fr">IPHC</a> laboratories.</string>
-    <string name="About_website">For more informations, visit the website: <a href="https://cetoolbox.github.io/">https://cetoolbox.github.io/</a></string>
+    <string name="About_equations">The theoretical equations used by CEToolbox are described in the following document: <a href="https://cetoolbox.github.io/resources/cetoolbox-equations.pdf">https://cetoolbox.github.io/resources/cetoolbox-equations.pdf</a></string>
+    <string name="About_website">For more information, visit the website: <a href="https://cetoolbox.github.io/">https://cetoolbox.github.io/</a></string>
     <string name="About_license">CEToolbox is
     licensed under the Apache License, Version 2.0. You may obtain a copy of the License at: <a href="https://www.apache.org/licenses/LICENSE-2.0.txt">https://www.apache.org/licenses/LICENSE-2.0.txt</a></string>
     <string name="TimePeak1">Time peak 1</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -57,7 +57,8 @@
     <string name="About_description">The Capillary Electrophoresis (CE) Toolbox is a software for computing
     Capillary Electrophoresis parameters developed by the <a href="https://complex-matter.unistra.fr/equipes-de-recherche/laboratoire-de-spectrometrie-de-masse-des-interactions-et-des-systemes/accueil/">LSMIS</a>
     and the <a href="http://www.iphc.cnrs.fr">IPHC</a> laboratories.</string>
-    <string name="About_website">For more informations, visit the website: <a href="https://cetoolbox.github.io/">https://cetoolbox.github.io/</a></string>
+    <string name="About_equations">The theoretical equations used by CEToolbox are described in the following document: <a href="https://cetoolbox.github.io/resources/cetoolbox-equations.pdf">https://cetoolbox.github.io/resources/cetoolbox-equations.pdf</a></string>
+    <string name="About_website">For more information, visit the website: <a href="https://cetoolbox.github.io/">https://cetoolbox.github.io/</a></string>
     <string name="About_license">CEToolbox is
     licensed under the Apache License, Version 2.0. You may obtain a copy of the License at: <a href="https://www.apache.org/licenses/LICENSE-2.0.txt">https://www.apache.org/licenses/LICENSE-2.0.txt</a></string>
     <string name="TimePeak1">Time peak 1</string>


### PR DESCRIPTION
This release contains minor fixes:
* A link to the equations used by CEToolbox has been added
* The unit used for mobility has been modified to m2/(V.s)
* The unit of conductivity has been modified to mS/m
* The default unit for concentration is now mmol/L