### PR TITLE
Fixed the occluded (blocked) texts on the injection tab

### DIFF
--- a/app/src/main/res/layout/injection.xml
+++ b/app/src/main/res/layout/injection.xml
@@ -25,7 +25,8 @@
 
         <TableRow
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" >
+            android:layout_height="wrap_content"
+            android:gravity="center">
 
             <TextView
                 android:layout_width="wrap_content"
@@ -53,7 +54,8 @@
 
         <TableRow
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" >
+            android:layout_height="wrap_content"
+            android:gravity="center">
 
             <TextView
                 android:layout_width="wrap_content"
@@ -78,7 +80,8 @@
 
         <TableRow
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" >
+            android:layout_height="wrap_content"
+            android:gravity="center">
 
             <TextView
                 android:layout_width="wrap_content"
@@ -205,7 +208,8 @@
 
         <TableRow
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" >
+            android:layout_height="wrap_content"
+            android:gravity="center">
 
             <TextView
                 android:layout_width="wrap_content"


### PR DESCRIPTION
Dear developer:

Hello! I am the creator of issue #13, and I have fixed the occluded (blocked) texts on the injection tab. I would genuinely appreciate it if you could kindly revise my code and leave me some advice. Thank you so much for your precious time!

Here are the screenshots after my changes:

<img src="https://user-images.githubusercontent.com/25502419/131611016-9cc53407-6e76-4b13-b17a-d1d45c8be8c4.png" alt="copy" width="250"/> <img src="https://user-images.githubusercontent.com/25502419/131611020-730adfba-0639-4dba-8b54-28dd42730af4.png" alt="copy" width="250"/>

Thanks again! Blessings on your day! :)