### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/conductivity.xml
+++ b/app/src/main/res/layout/conductivity.xml
@@ -158,6 +158,7 @@
 
             <Button
                 android:id="@+id/button1"
+                android:textColor="#007E96"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 style="?android:attr/buttonBarButtonStyle"

--- a/app/src/main/res/layout/flowrate.xml
+++ b/app/src/main/res/layout/flowrate.xml
@@ -160,6 +160,7 @@
 
             <Button
                 android:id="@+id/button1"
+                android:textColor="#007E96"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 style="?android:attr/buttonBarButtonStyle"

--- a/app/src/main/res/layout/injection.xml
+++ b/app/src/main/res/layout/injection.xml
@@ -260,6 +260,7 @@
 
             <Button
                 android:id="@+id/button1"
+                android:textColor="#007E96"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 style="?android:attr/buttonBarButtonStyle"

--- a/app/src/main/res/layout/mobility.xml
+++ b/app/src/main/res/layout/mobility.xml
@@ -660,6 +660,7 @@
 
             <Button
                 android:id="@+id/button1"
+                android:textColor="#007E96"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 style="?android:attr/buttonBarButtonStyle"

--- a/app/src/main/res/layout/viscosity.xml
+++ b/app/src/main/res/layout/viscosity.xml
@@ -160,6 +160,7 @@
 
             <Button
                 android:id="@+id/button1"
+                android:textColor="#007E96"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 style="?android:attr/buttonBarButtonStyle"


### PR DESCRIPTION
The original text color of the component is '#009688', and the contrast between the text color ('#009688') and the background color ('#FAFAFA') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#007E96') are as follows:
![image](https://user-images.githubusercontent.com/101503193/184938202-15d8d362-c201-4897-80b3-b054123c4b92.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.